### PR TITLE
loekl/update-mwaa-local-mem

### DIFF
--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -15,6 +15,11 @@ services:
 
     local-runner:
         image: amazon/mwaa-local:2.0.2
+        deploy:
+          resources:
+            limits:
+              cpus: '2'
+              memory: 4048M
         restart: always
         depends_on:
             - postgres

--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -17,6 +17,9 @@ pip3 install $PIP_OPTION celery[sqs]
 # install postgres python client
 pip3 install $PIP_OPTION psycopg2
 
+# setuptools dropped support for use_2to3 in v58+ and psycopg2 will install the latest v59+ version
+pip3 install $PIP_OPTION "setuptools<=57.*"
+
 # install minimal Airflow packages
 pip3 install $PIP_OPTION --constraint /constraints.txt apache-airflow[crypto,celery,statsd"${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}"]=="${AIRFLOW_VERSION}"
 


### PR DESCRIPTION
This PR brings `alan-eu/aws-mwaa-local-runner` up to date with `aws/aws-mwaa-local-runner` & enhances the container memory limits to avoid DAG OoM.