### PR TITLE
Update google_auth version in requirements.txt

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,7 +10,7 @@ businesstimedelta==1.0.1
 holidays==0.11.3.1
 slack-sdk==3.5.0
 google-api-python-client==1.12.8
-google-auth==1.29.0
+google-auth==2.13.0
 beautifulsoup4==4.7.1
 pytest==6.2.3
 simple_salesforce==1.11.1


### PR DESCRIPTION
This change is motivated by failure in running `task run-test`

Stackoverflow issue (created today 25 Oct 2022) https://stackoverflow.com/questions/74189694/cannot-import-name-external-account-authorized-user-from-google-auth 

Merge in google code leading to change in behavior https://github.com/googleapis/google-auth-library-python-oauthlib/pull/240/files#diff-63cdf7d9059947cf2f03b72a8137b8a1901de52f685705c251886d58a75b9381L8

With this update everything works find. 

For the reviewer: Might be worth a try to re-run this run-test locally and see if the issue is reproduced

I, unfortunately, have no idea at that point whether this change will create inconsistencies with the rest of the code 