### PR TITLE
Fix the amazonlinux image version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 # DESCRIPTION: Amazon MWAA Local Dev Environment
 # BUILD: docker build --rm -t amazon/mwaa-local .
 
-FROM public.ecr.aws/amazonlinux/amazonlinux
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 LABEL maintainer="amazon"
 
 # Airflow


### PR DESCRIPTION
Context [here](https://alanhealth.slack.com/archives/CBD6470LD/p1678977080486229)

There’s an [ongoing issue](https://github.com/aws/aws-mwaa-local-runner/issues/227) with `aws-mwaa-local-runner` . If you run task debug-airflow , you will most likely end up with an error.

To fix the issue, we set a stable version for the `amazonlinux` image.