### PR TITLE
Disable parallelism for local webserver

### DIFF
--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -21,6 +21,7 @@ services:
         environment:
             - LOAD_EX=n
             - EXECUTOR=Local
+            - AIRFLOW__WEBSERVER__WORKERS=1
         logging:
             options:
                 max-size: 10m


### PR DESCRIPTION
## Why?

Our local MWAA creates 4 workers for our simple dev environment. It consumes tons of CPU/RAM, and causes lots of issues:
* Crashing the whole process
* Not refreshing DAGs often enough
* ...

This PR reduces to 1 worker to disable web server parallelism, because we really don't need it.