### PR TITLE
Stop running `test-requirements` in interactive mode to fix CI

### DIFF
--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -68,7 +68,7 @@ test-requirements)
      echo "Container amazon/mwaa-local:$AIRFLOW_VERSION not built. Building locally."
      build_image
    fi
-   docker run -v $(pwd)/dags:/usr/local/airflow/dags -v $(pwd)/plugins:/usr/local/airflow/plugins -v $(pwd)/requirements:/usr/local/airflow/requirements -it amazon/mwaa-local:$AIRFLOW_VERSION test-requirements
+   docker run -v $(pwd)/dags:/usr/local/airflow/dags -v $(pwd)/plugins:/usr/local/airflow/plugins -v $(pwd)/requirements:/usr/local/airflow/requirements amazon/mwaa-local:$AIRFLOW_VERSION test-requirements
    ;;
 test-startup-script)
    BUILT_IMAGE=$(docker images -q amazon/mwaa-local:$AIRFLOW_VERSION)


### PR DESCRIPTION
## Why?

When running `mwaa-local-runner test-requirements`, it tries to execute the Docker image in interactive mode. This obviously fails in the CI (since CI is not interactive). 

That's a regression (it did not happen a year ago, it probably arose when we upgraded this repo to 2.8 by syncing with the original one).

This PR simply removes the interactive tag, which should fix the CI.

[Example of a failed CI run because of that issue](https://github.com/alan-eu/alan-jobs/actions/runs/11327801170/job/31499640520).