### PR TITLE
Add placeholder file for AWS credentials environment variables

### DIFF
--- a/docker/config/.env.aws
+++ b/docker/config/.env.aws
@@ -1,0 +1,2 @@
+# You can add your AWS environment variables here
+# We keep that file separate from .env.localrunner so that it can be updated by the startup script

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -46,3 +46,4 @@ services:
             retries: 3
         env_file:
             - ./config/.env.localrunner
+            - ./config/.env.aws


### PR DESCRIPTION
With the new `granted` based approach to managing our AWS credentials, we can't rely on the hardcoded default AWS credentials when using MWAA local runner. Instead, we need to assume our role, export its temporary credentials to env variables, copy these variables to a file, and load that file when starting the MWAA local runner. 

This PR simply adds the placeholder file to receive the environment variable. It's a different file from the existing `.env.localrunner` so that it can be overwritten every time we launch the MWAA localrunner without overwritting other variables in `.env.localrunner`.

This is a companion pull request to https://github.com/alan-eu/alan-jobs/pull/11072